### PR TITLE
[2/2] audio: Allow opting out of speaker_layout_channel_mask field

### DIFF
--- a/audio/common/all-versions/default/Android.bp
+++ b/audio/common/all-versions/default/Android.bp
@@ -80,6 +80,11 @@ cc_defaults {
         "libaudio_system_headers",
         "libhardware_headers",
     ],
+
+    cflags: select(soong_config_variable("android_hardware_audio", "skip_speaker_layout_channel_mask_field"), {
+        "true": ["-include common/all-versions/SkipSpeakerLayoutChannelMaskField.h"],
+        default: [],
+    }),
 }
 
 cc_library_shared {

--- a/audio/common/all-versions/util/include/common/all-versions/SkipSpeakerLayoutChannelMaskField.h
+++ b/audio/common/all-versions/util/include/common/all-versions/SkipSpeakerLayoutChannelMaskField.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#if defined(__ANDROID_VENDOR__) && !defined(SKIP_SPEAKER_LAYOUT_CHANNEL_MASK_FIELD)
+#define SKIP_SPEAKER_LAYOUT_CHANNEL_MASK_FIELD
+#endif


### PR DESCRIPTION
Adds the ability to fix Bluetooth ringtone on some devices that have had their audio HAL compiled before 15 QPR2.